### PR TITLE
Issue #4: Remove field type 'file'

### DIFF
--- a/image_url_formatter.module
+++ b/image_url_formatter.module
@@ -37,7 +37,7 @@ function image_url_formatter_field_formatter_info() {
   $formatters = array(
     'image_url' => array(
       'label' => t('Image URL'),
-      'field types' => array('file', 'image', 'imagefield_crop'),
+      'field types' => array('image', 'imagefield_crop'),
       'settings' => array(
         'url_type' => '',
         'image_style' => '',


### PR DESCRIPTION
It is not appropriate to apply this formatter to fields of type 'file'. It is only intended for image fields.